### PR TITLE
ruboty-sebastianのバージョンの更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 GIT
   remote: git://github.com/feedforce/ruboty-sebastian.git
-  revision: 6138dc5bb7982918787d1c6c0a3c6be2b8126c7d
+  revision: ce0e1e1e4d54b5970907a728633c17c1bf723337
   specs:
-    ruboty-sebastian (0.1.0)
+    ruboty-sebastian (0.7.0)
+      holiday_jp
+      nokogiri
       ruboty
       settingslogic
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 GIT
   remote: git://github.com/feedforce/ruboty-sebastian.git
-  revision: ce0e1e1e4d54b5970907a728633c17c1bf723337
+  revision: 23cb39c831f957775a2ad553824218616a343de0
   specs:
     ruboty-sebastian (0.7.0)
-      holiday_jp
       nokogiri
       ruboty
       settingslogic
@@ -11,7 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -28,7 +27,7 @@ GEM
       json
       rack
       slop
-    dotenv (2.0.1)
+    dotenv (2.0.2)
     era_ja (0.3.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -116,7 +115,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     settingslogic (2.0.9)
-    slop (4.1.0)
+    slop (4.2.0)
     syoboi_calendar (0.3.1)
       activesupport
       faraday


### PR DESCRIPTION
# 目的

ruboty-sebastianのバージョンを0.7.0に変更します。

# 理由

現在のfeedforce-rubotyで動作しているruboty-sebastianのバージョンは0.1.0で古いため、最新の0.7.0に更新して動作確認を行なうためです。
