### PR TITLE
$ bundle update 2015-07-02

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.2)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -33,7 +33,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.8)
+    ffi (1.9.10)
     hashie (3.4.2)
     i18n (0.7.0)
     ikku (0.1.4)
@@ -48,9 +48,9 @@ GEM
       ffi (>= 1.9.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    octokit (3.8.0)
+    octokit (4.0.1)
       sawyer (~> 0.6.0, >= 0.5.3)
-    rack (1.6.1)
+    rack (1.6.4)
     rake (10.4.2)
     redis (3.2.1)
     redis-namespace (1.5.2)
@@ -98,9 +98,9 @@ GEM
       ruboty
     ruboty-reminder (0.2.2)
       ruboty
-    ruboty-slack (0.1.7)
+    ruboty-slack (0.1.9)
       ruboty (>= 1.0.4)
-      xrc (>= 0.0.6)
+      xrc (>= 0.1.8)
     ruboty-syoboi_calendar (0.0.7)
       activesupport
       ruboty
@@ -132,7 +132,7 @@ GEM
       nokogiri
       rack
       rake (>= 0.9.2)
-    xrc (0.1.5)
+    xrc (0.1.8)
       activesupport
 
 PLATFORMS


### PR DESCRIPTION
Slackの仕様が変わって、rubotyが動かないのが現状です。
バージョンアップすれば動くみたいです。

https://twitter.com/r7kamura/status/616136186428420096

https://twitter.com/r7kamura/status/616155557112614912

https://github.com/r7kamura/ruboty-slack/commit/9d366d81566975f508002cf2f8858b46b59cdb77