### PR TITLE
$ bundle update 2015-07-02(3回目)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       ruboty
     ruboty-reminder (0.2.2)
       ruboty
-    ruboty-slack (0.1.10)
+    ruboty-slack (0.1.11)
       ruboty (>= 1.0.4)
       xrc (>= 0.1.8)
     ruboty-syoboi_calendar (0.0.7)


### PR DESCRIPTION
何度もすみません！
`ruboty-slack 0.1.10`にはバグがあったみたいなので…。