### PR TITLE
Use deppbot.com instead of tachikoma.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Every push to master will deploy to Heroku.
 Automatically `$ bundle update`
 -------------------------------
 
-Automatically update by http://tachikoma.io/
+Automatically update by https://www.deppbot.com which the account is [@masutaka](https://github.com/masutaka).


### PR DESCRIPTION
deppbot に乗り換えてみたので、README.md を更新しました。
すでに tachikoma.io の連携は切って、deppbot に変更しています。

https://github.com/feedforce/tech.feedforce.jp/pull/131 もご覧ください。