### PR TITLE
Remove ruboty-talk gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'ruboty-redis'
 gem 'ruboty-reminder'
 gem 'ruboty-slack_rtm'
 gem 'ruboty-syoboi_calendar'
-gem 'ruboty-talk'
 gem 'ruboty-wareki'
 
 gem 'nokogiri', '>= 1.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,13 +12,6 @@ GEM
     chrono (0.4.0)
       activesupport
     concurrent-ruby (1.0.5)
-    docomoru (0.1.4)
-      activesupport
-      faraday
-      faraday_middleware
-      json
-      rack
-      slop
     dotenv (2.4.0)
     era_ja (0.5.3)
     event_emitter (0.2.6)
@@ -36,7 +29,6 @@ GEM
       concurrent-ruby (~> 1.0)
     ikku (0.1.4)
       natto
-    json (2.1.0)
     mem (0.1.5)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -109,9 +101,6 @@ GEM
       activesupport
       ruboty
       syoboi_calendar (= 0.3.1)
-    ruboty-talk (0.0.5)
-      docomoru (>= 0.0.3)
-      ruboty (>= 1.1.0)
     ruboty-wareki (1.0.0)
       era_ja
       ruboty
@@ -169,7 +158,6 @@ DEPENDENCIES
   ruboty-reminder
   ruboty-slack_rtm
   ruboty-syoboi_calendar
-  ruboty-talk
   ruboty-wareki
 
 RUBY VERSION


### PR DESCRIPTION
## Why?

API の仕様変更に伴い、既存の gem が使えなくなったため。

```
┏━┓
┃ ┃自然対話APIへの移行のお願い
┗━╋…─────────────────────────────────────

3/28にご案内させていただきました通り、自然対話APIの提供に伴い、
以下の4つの対話系APIの提供を6月末をもって終了いたします。

・「雑談対話」
・「発話理解」
・「知識Q&A」
・「シナリオ対話」

3/26に提供を開始した自然対話APIでは廃止予定の各APIと同様の機能を
ご提供しておりますので、お手数ではございますが、積極的な移行をお願いいたします。
※以下は廃止予定の対話系APIと自然対話APIの各機能との対応です。

・「雑談対話」→「自然対話：雑談対話」
・「発話理解」→「自然対話：意図解釈」
・「知識Q&A」→「自然対話：知識検索」
・「シナリオ対話」→「自然対話：FAQチャット」

また、多くのご要望をいただいたため、自然対話APIに関しましても
商用での利用が可能となるようガイドラインを変更いたしました。

ご迷惑をおかけしますが、何卒ご理解を賜りますよう、
よろしくお願い申し上げます。
```

ちなみにログには既にエラーが出ている。

```
$ heroku logs -a feedforce-ruboty
...
2018-08-22T03:44:10.718286+00:00 app[bot.1]: E, [2018-08-22T12:44:10.718156 #4] ERROR -- : Error: NoMethodError: undefined method `[]' for nil:NilClass
2018-08-22T03:44:10.718301+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/action.rb:16:in `call'
2018-08-22T03:44:10.718298+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-talk-0.0.5/lib/ruboty/handlers/talk.rb:20:in `talk'
2018-08-22T03:44:10.718304+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/handlers/base.rb:32:in `block in call'
2018-08-22T03:44:10.718305+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/handlers/base.rb:31:in `each'
2018-08-22T03:44:10.718307+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/handlers/base.rb:31:in `inject'
2018-08-22T03:44:10.718308+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/handlers/base.rb:31:in `call'
2018-08-22T03:44:10.718310+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/robot.rb:31:in `block in receive'
2018-08-22T03:44:10.718312+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/robot.rb:30:in `each'
2018-08-22T03:44:10.718313+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-1.3.0/lib/ruboty/robot.rb:30:in `receive'
2018-08-22T03:44:10.718315+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-slack_rtm-3.1.0/lib/ruboty/adapters/slack_rtm.rb:161:in `on_message'
2018-08-22T03:44:10.718317+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-slack_rtm-3.1.0/lib/ruboty/adapters/slack_rtm.rb:83:in `block in bind'
2018-08-22T03:44:10.718319+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/ruboty-slack_rtm-3.1.0/lib/ruboty/slack_rtm/client.rb:28:in `block in on_text'
2018-08-22T03:44:10.718320+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/event_emitter-0.2.6/lib/event_emitter/emitter.rb:53:in `instance_exec'
2018-08-22T03:44:10.718322+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/event_emitter-0.2.6/lib/event_emitter/emitter.rb:53:in `block in emit'
2018-08-22T03:44:10.718324+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/event_emitter-0.2.6/lib/event_emitter/emitter.rb:48:in `each'
2018-08-22T03:44:10.718325+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/event_emitter-0.2.6/lib/event_emitter/emitter.rb:48:in `emit'
2018-08-22T03:44:10.718327+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.3.0/gems/websocket-client-simple-0.3.0/lib/websocket-client-simple/client.rb:58:in `block in connect'
```

## How?

* `ruboty-talk` gem を `Gemfile` から削除して `$ bundle` した

雑に grep で削除漏れの確認もした。

```
$ ag -c docomo

$ ag -c talk

```

## Merge conditions

* [x] 誰か一人の Approve

## How to check operation

gem の削除だけなので特に不要です。

## Todo after merging

* [ ] `$ heroku config:unset DOCOMO_API_KEY -a feedforce-ruboty` を実行する