### PR TITLE
継続的 bundle update の再導入

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ruby-orbs: sue445/ruby-orbs@1.3.7
+  ruby-orbs: sue445/ruby-orbs@1.3.8
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+orbs:
+  ruby-orbs: sue445/ruby-orbs@1.3.6
+
+workflows:
+  version: 2
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "00 16 * * 0" # 1:00am every Monday (JST)
+          filters:
+            branches:
+              only: master
+
+    jobs:
+      - ruby-orbs/bundle-update-pr:
+          image: "circleci/ruby:2.3.3"
+          pre-bundle-update-pr:
+            - run:
+                name: "Set timezone to Asia/Tokyo"
+                command: "sudo cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime"
+          git_user_name: "feedforce tech team"
+          git_user_email: "technical_staff@feedforce.jp"
+          github_access_token: "$GITHUB_ACCESS_TOKEN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ruby-orbs: sue445/ruby-orbs@1.3.6
+  ruby-orbs: sue445/ruby-orbs@1.3.7
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ruby-orbs: sue445/ruby-orbs@1.3.8
+  ruby-orbs: sue445/ruby-orbs@1.3.9
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Every push to master will deploy to Heroku.
 Automatically `$ bundle update`
 -------------------------------
 
-Automatically update by https://www.deppbot.com which the account is [@masutaka](https://github.com/masutaka).
+Automatically update by [circleci-bundle-update-pr](https://github.com/masutaka/circleci-bundle-update-pr) which the account is [@feedforce-bot](https://github.com/feedforce-bot).


### PR DESCRIPTION
## Why?

以前 deppbot を使って継続的 bundle update を行なっていた (例: https://github.com/feedforce/feedforce-ruboty/pull/125) が、いつの間にか音沙汰がなくなっていたので、[circleci-bundle-update-pr](https://github.com/masutaka/circleci-bundle-update-pr) を使ったやり方に切り替える。

## How?

* `.circleci/config.yml` を書いて https://github.com/sue445/circleci-ruby-orbs の Orb を使うようにした
    * 実行周期は `1:00am every Monday (JST)` (なんとなく深夜)
    * git の username, email は [ruby-rpm リポジトリで使っている値](https://github.com/feedforce/ruby-rpm/blob/bd5956bfe0e024115fd5a918cc2a6de6032d419e/.circleci/config.yml#L25-L26)と同じにした
* サードパーティ Orb を使えるようにするため、CircleCI の feedforce オーガニゼーション全体でサードパーティ Orb の使用を許可した
    * https://circleci.com/gh/organizations/feedforce/settings#security
* CircleCI にこのリポジトリを Add projets した

    ![image](https://user-images.githubusercontent.com/10208211/48826544-f5935a00-edad-11e8-82d9-b4c487341f87.png)

    <img width="1607" alt="_2018_11_21_16_54" src="https://user-images.githubusercontent.com/10208211/48826590-1360bf00-edae-11e8-84b2-3c2e5c1d411d.png">

* ~~一旦 @tsub のアカウントで~~ GitHub のアクセストークンを作って https://circleci.com/gh/feedforce/feedforce-ruboty/edit#env-vars から `$GITHUB_ACCESS_TOKEN` を設定した
    * @feedforce-bot でアクセストークンを作成し直しました
    * scope は[ドキュメント](https://github.com/masutaka/circleci-bundle-update-pr/tree/7b5cd1263b2076074d8f6a2d12820e8e56beb0a9#setting-github-personal-access-token-to-circleci)にある通り `repo` だけ
* CircleCI 2.1 の設定ファイルを使えるようにするため、 https://circleci.com/gh/feedforce/feedforce-ruboty/edit#advanced-settings から `Enable build processing (preview)` を On にした

    ![image](https://user-images.githubusercontent.com/10208211/48827175-d39ad700-edaf-11e8-9057-52105feb3a00.png)

## How to check operation

1. コミット 428a3e1 を一時的に Push して bundle update のジョブを実行する
1. [bundle update が成功](https://circleci.com/gh/feedforce/feedforce-ruboty/13)して、https://github.com/feedforce/feedforce-ruboty/pull/131 のような PR が作られること
1. `$ git reset --hard HEAD~ && git push -f origin introduce-continuous-bundle-update` を実行して検証用コミットを削除
1. PR https://github.com/feedforce/feedforce-ruboty/pull/131 も動作確認用なので一旦クローズ

## 困っていること

* [x] GitHub のアクセストークンが必要だが、それに適した GitHub ユーザーがいない https://github.com/feedforce/feedforce-ruboty/pull/128#issuecomment-440598180