### PR TITLE
Use forked ruboty-github to add default GitHub access token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 source 'https://rubygems.org'
 ruby '2.6.3'
 
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 # Please sort
 gem 'rake'
 gem 'ruboty-alias'
 gem 'ruboty-cron'
 gem 'ruboty-echo'
-gem 'ruboty-github'
+gem 'ruboty-github', github: 'feedforce/ruboty-github', branch: 'add-default-access-token'
 gem 'ruboty-redis'
 gem 'ruboty-slack_rtm'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/feedforce/ruboty-github.git
+  revision: db1a2087488b4e003ed701c1a05aa0c0fff659e8
+  branch: add-default-access-token
+  specs:
+    ruboty-github (0.3.0)
+      activesupport
+      octokit
+      ruboty
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,10 +62,6 @@ GEM
       ruboty (>= 0.2.0)
     ruboty-echo (0.1.1)
       ruboty
-    ruboty-github (0.3.0)
-      activesupport
-      octokit
-      ruboty
     ruboty-redis (0.0.6)
       redis
       redis-namespace
@@ -95,7 +101,7 @@ DEPENDENCIES
   ruboty-alias
   ruboty-cron
   ruboty-echo
-  ruboty-github
+  ruboty-github!
   ruboty-redis
   ruboty-slack_rtm
 
@@ -103,4 +109,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
## Why?

以下の記事を参考に、Slack ワークフローから feedkun を呼び出してアプリをデプロイできるようにしたい。
→ [SlackワークフローとRubotyで最高のChatOps生活を \- Misoca開発者ブログ](https://tech.misoca.jp/entry/2019/10/25/111123)

Slack ワークフローから feedkun を呼び出そうとすると、GitHub のアクセストークンの登録・参照がうまくできないため、Ruboty 側に予め環境変数で設定しておいたデフォルト値のアクセストークンを参照させる形にしたい。

そのために ruboty-github を fork して拡張した → https://github.com/feedforce/ruboty-github/commit/db1a2087488b4e003ed701c1a05aa0c0fff659e8
(参考: https://github.com/standfirm/ruboty-github/commit/49e545c397acc5f834d06f290a0d5402223fdf71)

## How

* fork した ruboty-github をインストールする形に Gemfile を書き換えた
* Heroku App に `$GITHUB_ACCES_TOKEN` を設定
    * スコープは PR の作成とマージに必要な `repo` のみ
    * トークンは @social-plus-devel のものを使用 (今は一部のチームでしか利用していないため。他でも利用するようであれば全社的な GitHub アカウントで発行し直す)

ちなみに、本家 ruboty-github は最近は更新がないようなので、master を取り込んでアップデートする機会もほとんどないかと思う。